### PR TITLE
Розділити дані про оренду на два окремі файли: поточні та завершені

### DIFF
--- a/src/app/PS5RentalHubApp.java
+++ b/src/app/PS5RentalHubApp.java
@@ -1,9 +1,11 @@
 package app;
 
+import app.cvs.RentalCSVManager;
 import app.window.MainWindow;
 
 public class PS5RentalHubApp {
     public static void main(String[] args) {
+        RentalCSVManager.getInstance().refreshRentals();
         MainWindow mainWindow = new MainWindow();
         mainWindow.active();
     }

--- a/src/app/service/ConsoleService.java
+++ b/src/app/service/ConsoleService.java
@@ -40,14 +40,14 @@ public class ConsoleService {
     }
 
     private Set<String> getUsedConsoleSerialNumbers(Date startDate, Date endDate) {
-        List<Rental> rentals = RentalCSVManager.getInstance().readAllFromCSV();
+        List<Rental> rentals = RentalCSVManager.getInstance().readActualRentalsFromCSV();
 
         // Всі серійні номери консолей, які в цей період вже зайняті
         return rentals.stream()
                 .filter(rental -> (rental.getStart().equals(startDate) || rental.getEnd().equals(endDate))
                         || (rental.getStart().after(startDate) && rental.getStart().before(endDate))
                         || (rental.getEnd().after(startDate) && rental.getEnd().before(endDate)))
-                .map(rental -> rental.getSerialNumberOfConsole())
+                .map(Rental::getSerialNumberOfConsole)
                 .collect(Collectors.toSet());
     }
 }

--- a/src/app/service/RentalService.java
+++ b/src/app/service/RentalService.java
@@ -17,6 +17,6 @@ public class RentalService {
     }
 
     public void add(Rental rental) {
-        RentalCSVManager.getInstance().saveToCSV(rental);
+        RentalCSVManager.getInstance().saveActualRentalToCSV(rental);
     }
 }


### PR DESCRIPTION
Для пошуку вільної консолі всі записи про оренду зчитуються з файлу rentals.csv, що є зайвим кроком. Необхідно оптимізувати логіку, розділивши дані на два файли: один для актуальних записів, інший — для завершених оренд. Таким чином, для пошуку ми будемо використовувати лише актуальні записи.